### PR TITLE
Enhance Device class with actuator and control name properties

### DIFF
--- a/aiowiserbyfeller/device/device.py
+++ b/aiowiserbyfeller/device/device.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from aiowiserbyfeller.auth import Auth
+from aiowiserbyfeller.util import parse_wiser_device_fwid, parse_wiser_device_hwid_a
 
 
 class Device:
@@ -37,9 +38,19 @@ class Device:
         return self.raw_data["a"]
 
     @property
+    def actuator_name(self) -> str:
+        """Name of the actuator module (Funktionseinsatz)."""
+        return parse_wiser_device_hwid_a(self.raw_data["a"]["hw_id"])
+
+    @property
     def c(self) -> dict:
         """Information about the control module (Bedienaufsatz)."""
         return self.raw_data["c"]
+
+    @property
+    def control_name(self) -> str:
+        """Name of the control module (Bedienaufsatz)."""
+        return parse_wiser_device_fwid(self.raw_data["c"]["fw_id"])
 
     @property
     def inputs(self) -> list:

--- a/aiowiserbyfeller/device/device.py
+++ b/aiowiserbyfeller/device/device.py
@@ -13,6 +13,8 @@ class Device:
         """Initialize a device object."""
         self.raw_data = raw_data
         self.auth = auth
+        self._a_name = parse_wiser_device_hwid_a(raw_data["a"]["hw_id"])
+        self._c_name = parse_wiser_device_fwid(raw_data["c"]["fw_id"])
 
     @property
     def id(self) -> str:
@@ -38,9 +40,9 @@ class Device:
         return self.raw_data["a"]
 
     @property
-    def actuator_name(self) -> str:
+    def a_name(self) -> str:
         """Name of the actuator module (Funktionseinsatz)."""
-        return parse_wiser_device_hwid_a(self.raw_data["a"]["hw_id"])
+        return self._a_name
 
     @property
     def c(self) -> dict:
@@ -48,9 +50,9 @@ class Device:
         return self.raw_data["c"]
 
     @property
-    def control_name(self) -> str:
+    def c_name(self) -> str:
         """Name of the control module (Bedienaufsatz)."""
-        return parse_wiser_device_fwid(self.raw_data["c"]["fw_id"])
+        return self._c_name
 
     @property
     def inputs(self) -> list:

--- a/aiowiserbyfeller/map.py
+++ b/aiowiserbyfeller/map.py
@@ -1,0 +1,50 @@
+"""Various mappings."""
+
+# Maps the hw_id to A block
+DEVICE_A_BLOCK_HWID_MAP = [
+    {"name": "Secondary Control", "type": 0x0, "feature": None},
+    {"name": "On/Off", "type": 0x1, "feature": None},
+    {"name": "Dimmer", "type": 0x2, "feature": None},
+    {"name": "Motor", "type": 0x3, "feature": None},
+    {"name": "Thermostat", "type": 0x4, "feature": None},
+    {"name": "Valve Controller", "type": 0x4, "feature": 0x1},
+    {"name": "Dali", "type": 0x2, "feature": 0x1},
+    {"name": "Weather Station", "type": 0x0, "feature": 0x4},
+]
+
+# Maps the fw_id to C block
+DEVICE_C_BLOCK_FWID_MAP = {
+    0x8402: "Button Front",
+    0x8600: "µGateway Button Front",
+    0x9000: "Sensor Front",
+    0x9200: "Display Front",
+    0xA000: "Weather Station",
+    0xAA00: "Valve Controller",
+    0xBA00: "Push Button Interface",
+    0xC000: "DIN Rail Gateway",
+}
+
+# Maps the fw_id to A block
+DEVICE_A_BLOCK_FWID_MAP = {
+    0x0100: "On/Off / Secondary Control",
+    0x0200: "RL/RC Dimmer",
+    0x0210: "DALI Dimmer",
+    0x0220: "10V Dimmer",
+    0x0300: "Motor",
+    0x0400: "Thermostat",
+    0x0410: "Valve Controller",
+}
+
+# Combines the fw_id maps for A and C blocks
+DEVICE_A_BLOCK_FWID_BLOCK_MAP = [
+    {
+        "mask": 0x7E00,
+        "main_name": "C-Block",
+        "fw_id_map": DEVICE_C_BLOCK_FWID_MAP,
+    },
+    {
+        "mask": 0xFF0,
+        "main_name": "A-Block",
+        "fw_id_map": DEVICE_A_BLOCK_FWID_MAP,
+    },
+]

--- a/aiowiserbyfeller/util.py
+++ b/aiowiserbyfeller/util.py
@@ -155,6 +155,7 @@ def parse_wiser_device_hwid_a(value: str) -> str:
                 best_match = entry["name"]  # Temporarily set, but continue searching
     return best_match + (f" {channels}K" if channel_type != 0x0 else "")
 
+
 def parse_wiser_device_fwid(value: str) -> str:
     """Parse a Feller Wiser device firmware id."""
     if value in (None, ""):

--- a/aiowiserbyfeller/util.py
+++ b/aiowiserbyfeller/util.py
@@ -23,6 +23,7 @@ from .const import (
     DEVICE_GENERATION_B,
 )
 from .errors import InvalidArgument
+from .map import DEVICE_A_BLOCK_FWID_BLOCK_MAP, DEVICE_A_BLOCK_HWID_MAP
 
 
 def validate_str(value, valid, **kwargs):
@@ -128,74 +129,42 @@ def parse_wiser_device_ref_a(value: str) -> dict:
 
 def parse_wiser_device_hwid_a(value: str) -> str:
     """Parse a Feller Wiser actuator (Funktionseinsatz) hardware id."""
-    a_block_map = [
-        {"name": "NS", "type": 0x0, "feature": None},
-        {"name": "ONOFF", "type": 0x1, "feature": None},
-        {"name": "DIMMER", "type": 0x2, "feature": None},
-        {"name": "MOTOR", "type": 0x3, "feature": None},
-        {"name": "THERMOSTAT", "type": 0x4, "feature": None},
-        {"name": "VALVE CONTROLLER", "type": 0x4, "feature": 0x1},
-        {"name": "DALI", "type": 0x2, "feature": 0x1},
-        {"name": "WEATHER STATION", "type": 0x0, "feature": 0x4},
-    ]
     if value in (None, ""):
-        return "UNKNOWN"
+        return "Unknown"
 
     value = int(value, 16)
     channel_type = (value >> 8) & 0x0F
     channel_features = (value >> 4) & 0x0F
     channels = (value >> 12) & 0x07
-    best_match = "UNKNOWN"
-    for entry in a_block_map:
+    best_match = "Unknown"
+    for entry in DEVICE_A_BLOCK_HWID_MAP:
         if entry["type"] == channel_type:
             if entry["feature"] == channel_features:
                 best_match = entry["name"]
                 break  # Exact match
             if entry["feature"] is None:
                 best_match = entry["name"]  # Temporarily set, but continue searching
+
     return best_match + (f" {channels}K" if channels != 0x0 else "")
 
 
-def parse_wiser_device_fwid(value: str) -> str:
+def parse_wiser_device_fwid(value: str, include_block_suffix: bool = False) -> str:
     """Parse a Feller Wiser device firmware id."""
     if value in (None, ""):
         return "Unknown"
 
-    c_block_map = {
-        0x8402: "Button-Front",
-        0x8600: "microGW Button-Front",
-        0x9000: "Sensor-Front",
-        0x9200: "Display-Front",
-        0xA000: "WEST-Interface",
-        0xAA00: "Valve-Controller",
-        0xBA00: "Push-Button-Interface",
-        0xC000: "DinRailGW",
-    }
-    a_block_map = {
-        0x0100: "OnOff/NS",
-        0x0200: "RLRC-Dimmer",
-        0x0210: "DALI-Dimmer",
-        0x0220: "10V-Dimmer",
-        0x0300: "Motor",
-        0x0400: "Thermostat",
-        0x0410: "Valve-Controller",
-    }
-    block_map = [
-        {
-            "mask": 0x7E00,
-            "main_name": "C-Block",
-            "fw_id_map": c_block_map,
-        },
-        {
-            "mask": 0xFF0,
-            "main_name": "A-Block",
-            "fw_id_map": a_block_map,
-        },
-    ]
     fw_id = int(value, 16)
-    b = block_map[0] if (fw_id & 0x8000) else block_map[1]
+    b = (
+        DEVICE_A_BLOCK_FWID_BLOCK_MAP[0]
+        if (fw_id & 0x8000)
+        else DEVICE_A_BLOCK_FWID_BLOCK_MAP[1]
+    )
 
     for map_fwid, name in b["fw_id_map"].items():
         if (map_fwid & b["mask"]) == (fw_id & b["mask"]):
-            return f"{name} {b['main_name']}"
+            if include_block_suffix:
+                return f"{name} {b['main_name']}"
+
+            return f"{name}"
+
     return "Unknown"

--- a/aiowiserbyfeller/util.py
+++ b/aiowiserbyfeller/util.py
@@ -162,9 +162,6 @@ def parse_wiser_device_fwid(value: str, include_block_suffix: bool = False) -> s
 
     for map_fwid, name in b["fw_id_map"].items():
         if (map_fwid & b["mask"]) == (fw_id & b["mask"]):
-            if include_block_suffix:
-                return f"{name} {b['main_name']}"
-
-            return f"{name}"
+            return name + (f" {b['main_name']}" if include_block_suffix else "")
 
     return "Unknown"

--- a/aiowiserbyfeller/util.py
+++ b/aiowiserbyfeller/util.py
@@ -153,7 +153,7 @@ def parse_wiser_device_hwid_a(value: str) -> str:
                 break  # Exact match
             if entry["feature"] is None:
                 best_match = entry["name"]  # Temporarily set, but continue searching
-    return best_match + (f" {channels}K" if channel_type != 0x0 else "")
+    return best_match + (f" {channels}K" if channels != 0x0 else "")
 
 
 def parse_wiser_device_fwid(value: str) -> str:

--- a/tests/test_api_devices.py
+++ b/tests/test_api_devices.py
@@ -56,15 +56,15 @@ async def test_async_get_devices(client_api_auth, mock_aioresponse):
                     "hw_id": "",
                     "fw_version": "0x20606000",
                     "fw_id": "",
-                    "address": "0x00023698"
+                    "address": "0x00023698",
                 },
                 "c": {
                     "hw_id": "",
                     "fw_version": "0x20606000",
                     "fw_id": "",
-                    "cmd_matrix": "0x0001"
-                }
-            }
+                    "cmd_matrix": "0x0001",
+                },
+            },
         ],
     }
 

--- a/tests/test_api_devices.py
+++ b/tests/test_api_devices.py
@@ -80,12 +80,12 @@ async def test_async_get_devices(client_api_auth, mock_aioresponse):
     assert actual[0].last_seen == 25
     assert actual[0].a == response_json["data"][0]["a"]
     assert actual[0].c == response_json["data"][0]["c"]
-    assert actual[0].actuator_name == "DIMMER 1K"
-    assert actual[0].control_name == "Button-Front C-Block"
-    assert actual[1].actuator_name == "UNKNOWN 1K"
-    assert actual[1].control_name == "Unknown"
-    assert actual[2].actuator_name == "UNKNOWN"
-    assert actual[2].control_name == "Unknown"
+    assert actual[0].a_name == "Dimmer 1K"
+    assert actual[0].c_name == "Button Front"
+    assert actual[1].a_name == "Unknown 1K"
+    assert actual[1].c_name == "Unknown"
+    assert actual[2].a_name == "Unknown"
+    assert actual[2].c_name == "Unknown"
 
 
 @pytest.mark.asyncio
@@ -134,9 +134,9 @@ async def test_async_get_devices_detail(client_api_auth, mock_aioresponse):
     assert actual[0].a == response_json["data"][0]["a"]
     assert actual[0].inputs == response_json["data"][0]["inputs"]
     assert actual[0].outputs == response_json["data"][0]["outputs"]
-    assert actual[0].actuator_name == "ONOFF 1K"
-    assert actual[0].control_name == "Button-Front C-Block"
-    assert actual[0].actuator_name == "ONOFF 1K"
+    assert actual[0].a_name == "On/Off 1K"
+    assert actual[0].c_name == "Button Front"
+    assert actual[0].a_name == "On/Off 1K"
 
     c_sn = response_json["data"][0]["c"]["serial_nr"]
     a_sn = response_json["data"][0]["a"]["serial_nr"]
@@ -187,8 +187,8 @@ async def test_async_get_device(client_api_auth, mock_aioresponse):
     assert actual.last_seen == 39
     assert actual.a == response_json["data"]["a"]
     assert actual.outputs == response_json["data"]["outputs"]
-    assert actual.actuator_name == "ONOFF 1K"
-    assert actual.control_name == "Button-Front C-Block"
+    assert actual.a_name == "On/Off 1K"
+    assert actual.c_name == "Button Front"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_devices.py
+++ b/tests/test_api_devices.py
@@ -35,20 +35,36 @@ async def test_async_get_devices(client_api_auth, mock_aioresponse):
                 "id": "000004d7",
                 "last_seen": 6,
                 "a": {
-                    "fw_id": "0x0100",
-                    "hw_id": "0x1110",
+                    "fw_id": "0x010C",
+                    "hw_id": "0x1511",
                     "fw_version": "0x00501a30",
                     "address": "0x00000af6",
                     "comm_ref": "3404.A",
                 },
                 "c": {
-                    "fw_id": "0x8402",
+                    "fw_id": "0x9509",
                     "hw_id": "0x8443",
                     "fw_version": "0x00500a28",
                     "cmd_matrix": "0x0002",
                     "comm_ref": "926-3406-4.S4.A.F",
                 },
             },
+            {
+                "id": "00023698",
+                "last_seen": 31,
+                "a": {
+                    "hw_id": "",
+                    "fw_version": "0x20606000",
+                    "fw_id": "",
+                    "address": "0x00023698"
+                },
+                "c": {
+                    "hw_id": "",
+                    "fw_version": "0x20606000",
+                    "fw_id": "",
+                    "cmd_matrix": "0x0001"
+                }
+            }
         ],
     }
 
@@ -58,12 +74,18 @@ async def test_async_get_devices(client_api_auth, mock_aioresponse):
 
     actual = await client_api_auth.async_get_devices()
 
-    assert len(actual) == 2
+    assert len(actual) == 3
     assert isinstance(actual[0], Device)
     assert actual[0].id == "00000679"
     assert actual[0].last_seen == 25
     assert actual[0].a == response_json["data"][0]["a"]
     assert actual[0].c == response_json["data"][0]["c"]
+    assert actual[0].actuator_name == "DIMMER 1K"
+    assert actual[0].control_name == "Button-Front C-Block"
+    assert actual[1].actuator_name == "UNKNOWN 1K"
+    assert actual[1].control_name == "Unknown"
+    assert actual[2].actuator_name == "UNKNOWN"
+    assert actual[2].control_name == "Unknown"
 
 
 @pytest.mark.asyncio
@@ -97,7 +119,7 @@ async def test_async_get_devices_detail(client_api_auth, mock_aioresponse):
                 },
                 "inputs": [{"type": "up down"}],
                 "outputs": [{"load": 6, "type": "motor", "sub_type": ""}],
-            }
+            },
         ],
     }
 
@@ -112,6 +134,9 @@ async def test_async_get_devices_detail(client_api_auth, mock_aioresponse):
     assert actual[0].a == response_json["data"][0]["a"]
     assert actual[0].inputs == response_json["data"][0]["inputs"]
     assert actual[0].outputs == response_json["data"][0]["outputs"]
+    assert actual[0].actuator_name == "ONOFF 1K"
+    assert actual[0].control_name == "Button-Front C-Block"
+    assert actual[0].actuator_name == "ONOFF 1K"
 
     c_sn = response_json["data"][0]["c"]["serial_nr"]
     a_sn = response_json["data"][0]["a"]["serial_nr"]
@@ -162,6 +187,8 @@ async def test_async_get_device(client_api_auth, mock_aioresponse):
     assert actual.last_seen == 39
     assert actual.a == response_json["data"]["a"]
     assert actual.outputs == response_json["data"]["outputs"]
+    assert actual.actuator_name == "ONOFF 1K"
+    assert actual.control_name == "Button-Front C-Block"
 
 
 @pytest.mark.asyncio

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,8 @@ import pytest
 
 from aiowiserbyfeller import InvalidArgument
 from aiowiserbyfeller.util import (
+    parse_wiser_device_fwid,
+    parse_wiser_device_hwid_a,
     parse_wiser_device_ref_a,
     parse_wiser_device_ref_c,
     validate_str,
@@ -489,6 +491,43 @@ def ref_a_data() -> list[list]:
     ]
 
 
+def fwid_data() -> list[list]:
+    """Provide data for test_parse_wiser_device_hwid_a."""
+    return [
+        ["0x8402", "Button-Front C-Block"],
+        ["0x8600", "microGW Button-Front C-Block"],
+        ["0x9000", "Sensor-Front C-Block"],
+        ["0x9200", "Display-Front C-Block"],
+        ["0xA000", "WEST-Interface C-Block"],
+        ["0xAA00", "Valve-Controller C-Block"],
+        ["0xBA00", "Push-Button-Interface C-Block"],
+        ["0xC000", "DinRailGW C-Block"],
+        ["0x0100", "OnOff/NS A-Block"],
+        ["0x0200", "RLRC-Dimmer A-Block"],
+        ["0x0210", "DALI-Dimmer A-Block"],
+        ["0x0220", "10V-Dimmer A-Block"],
+        ["0x0300", "Motor A-Block"],
+        ["0x0400", "Thermostat A-Block"],
+        ["0x0410", "Valve-Controller A-Block"],
+    ]
+
+
+def hwid_data() -> list[list]:
+    """Provide data for test_parse_wiser_device_hwid_a."""
+    return [
+        ["0x0033", "NS"],
+        ["0x1113", "ONOFF 1K"],
+        ["0x1203", "DIMMER 1K"],
+        ["0x2203", "DIMMER 2K"],
+        ["0x1303", "MOTOR 1K"],
+        ["0x2303", "MOTOR 2K"],
+        ["0x6413", "VALVE CONTROLLER 6K"],
+        ["0x2212", "DALI 2K"],
+        ["0x0040", "WEATHER STATION"],
+        ["0x0400", "THERMOSTAT"],
+    ]
+
+
 @pytest.mark.parametrize("check_val", validate_str_data_valid())
 def test_validate_str_valid(check_val: list):
     """Test validate_str with valid values."""
@@ -524,4 +563,18 @@ def test_parse_wiser_device_ref_c(data: list):
 def test_parse_wiser_device_ref_a(data: list):
     """Test parse_wiser_device_ref_a."""
     actual = parse_wiser_device_ref_a(data[0])
+    assert actual == data[1]
+
+
+@pytest.mark.parametrize("data", hwid_data())
+def test_parse_wiser_device_hwid_a(data: list):
+    """Test parse_wiser_device_hwid_a."""
+    actual = parse_wiser_device_hwid_a(data[0])
+    assert actual == data[1]
+
+
+@pytest.mark.parametrize("data", fwid_data())
+def test_parse_wiser_device_fwid(data: list):
+    """Test parse_wiser_device_fwid."""
+    actual = parse_wiser_device_fwid(data[0])
     assert actual == data[1]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -494,37 +494,37 @@ def ref_a_data() -> list[list]:
 def fwid_data() -> list[list]:
     """Provide data for test_parse_wiser_device_hwid_a."""
     return [
-        ["0x8402", "Button-Front C-Block"],
-        ["0x8600", "microGW Button-Front C-Block"],
-        ["0x9000", "Sensor-Front C-Block"],
-        ["0x9200", "Display-Front C-Block"],
-        ["0xA000", "WEST-Interface C-Block"],
-        ["0xAA00", "Valve-Controller C-Block"],
-        ["0xBA00", "Push-Button-Interface C-Block"],
-        ["0xC000", "DinRailGW C-Block"],
-        ["0x0100", "OnOff/NS A-Block"],
-        ["0x0200", "RLRC-Dimmer A-Block"],
-        ["0x0210", "DALI-Dimmer A-Block"],
-        ["0x0220", "10V-Dimmer A-Block"],
-        ["0x0300", "Motor A-Block"],
-        ["0x0400", "Thermostat A-Block"],
-        ["0x0410", "Valve-Controller A-Block"],
+        ["0x8402", "Button Front", "C-Block"],
+        ["0x8600", "µGateway Button Front", "C-Block"],
+        ["0x9000", "Sensor Front", "C-Block"],
+        ["0x9200", "Display Front", "C-Block"],
+        ["0xA000", "Weather Station", "C-Block"],
+        ["0xAA00", "Valve Controller", "C-Block"],
+        ["0xBA00", "Push Button Interface", "C-Block"],
+        ["0xC000", "DIN Rail Gateway", "C-Block"],
+        ["0x0100", "On/Off / Secondary Control", "A-Block"],
+        ["0x0200", "RL/RC Dimmer", "A-Block"],
+        ["0x0210", "DALI Dimmer", "A-Block"],
+        ["0x0220", "10V Dimmer", "A-Block"],
+        ["0x0300", "Motor", "A-Block"],
+        ["0x0400", "Thermostat", "A-Block"],
+        ["0x0410", "Valve Controller", "A-Block"],
     ]
 
 
 def hwid_data() -> list[list]:
     """Provide data for test_parse_wiser_device_hwid_a."""
     return [
-        ["0x0033", "NS"],
-        ["0x1113", "ONOFF 1K"],
-        ["0x1203", "DIMMER 1K"],
-        ["0x2203", "DIMMER 2K"],
-        ["0x1303", "MOTOR 1K"],
-        ["0x2303", "MOTOR 2K"],
-        ["0x6413", "VALVE CONTROLLER 6K"],
-        ["0x2212", "DALI 2K"],
-        ["0x0040", "WEATHER STATION"],
-        ["0x0400", "THERMOSTAT"],
+        ["0x0033", "Secondary Control"],
+        ["0x1113", "On/Off 1K"],
+        ["0x1203", "Dimmer 1K"],
+        ["0x2203", "Dimmer 2K"],
+        ["0x1303", "Motor 1K"],
+        ["0x2303", "Motor 2K"],
+        ["0x6413", "Valve Controller 6K"],
+        ["0x2212", "Dali 2K"],
+        ["0x0040", "Weather Station"],
+        ["0x0400", "Thermostat"],
     ]
 
 
@@ -578,3 +578,10 @@ def test_parse_wiser_device_fwid(data: list):
     """Test parse_wiser_device_fwid."""
     actual = parse_wiser_device_fwid(data[0])
     assert actual == data[1]
+
+
+@pytest.mark.parametrize("data", fwid_data())
+def test_parse_wiser_device_fwid_with_blocktype(data: list):
+    """Test parse_wiser_device_fwid with blocktype."""
+    actual = parse_wiser_device_fwid(data[0], include_block_suffix=True)
+    assert actual == data[1] + " " + data[2]


### PR DESCRIPTION
Adds two new properties to the device class: `actuator_name` and `control_name`. They return the Wiser by Feller device names as it does on the gateway web interface. 

e.g.:
Actuator: `ONOFF 1K` or `UNKNOWN` 
Control: `Button-Front C-Block` or `Unknown`

This is based on the `http://{gwip}/kPlus/lib.js`