### PR TITLE
Device: Implement new color parameters

### DIFF
--- a/aiowiserbyfeller/device/device.py
+++ b/aiowiserbyfeller/device/device.py
@@ -142,7 +142,13 @@ class Device:
         return resp["ping"] == "pong"
 
     async def async_status(
-        self, channel: int, color: str, background_bri: int, foreground_bri: int | None
+        self,
+        channel: int,
+        color: str,
+        background_bri: int,
+        foreground_bri: int | None,
+        foreground_color: str | None = None,
+        background_color: str | None = None,
     ) -> None:
         """Set status light of load."""
 
@@ -153,6 +159,12 @@ class Device:
             "color": color,
             "background_bri": background_bri,
             "foreground_bri": foreground_bri,
+            "foreground_color": foreground_color
+            if foreground_color is not None
+            else color,
+            "background_color": background_color
+            if background_color is not None
+            else color,
         }
 
         config = await self.auth.request("get", f"devices/{self.id}/config")

--- a/tests/test_api_devices.py
+++ b/tests/test_api_devices.py
@@ -888,6 +888,8 @@ async def test_async_status(
         "color": "#552030",
         "background_bri": 100,
         "foreground_bri": foreground_expected,
+        "foreground_color": "#552030",
+        "background_color": "#552030",
     }
 
     update_response = {
@@ -919,3 +921,74 @@ async def test_async_status(
 
     device = Device(DEVICE_RAW_DATA, client_api_auth.auth)
     await device.async_status(0, "#552030", 100, foreground_param)
+
+
+@pytest.mark.asyncio
+async def test_async_status_with_separate_colors(client_api_auth, mock_aioresponse):
+    """Test async_status with explicit foreground_color and background_color."""
+
+    config_response = {
+        "status": "success",
+        "data": {
+            "id": 4294976294,
+            "inputs": [
+                {
+                    "type": "button",
+                    "color": "#1abcf2",
+                    "foreground_color": "#1cf22b",
+                    "background_color": "#f21c1c",
+                    "background_bri": 0,
+                    "foreground_bri": 0,
+                }
+            ],
+            "outputs": [],
+            "design": {"color": 0, "name": "edizio_due"},
+        },
+    }
+
+    await prepare_test_authenticated(
+        mock_aioresponse,
+        f"{BASE_URL}/devices/00000679/config",
+        "get",
+        config_response,
+    )
+
+    update_request = {
+        "color": "#1abcf2",
+        "background_bri": 50,
+        "foreground_bri": 50,
+        "foreground_color": "#1cf22b",
+        "background_color": "#f21c1c",
+    }
+
+    update_response = {
+        "status": "success",
+        "data": {
+            "type": "button",
+            "color": "#1abcf2",
+            "foreground_color": "#1cf22b",
+            "background_color": "#f21c1c",
+            "background_bri": 50,
+            "foreground_bri": 50,
+        },
+    }
+
+    await prepare_test_authenticated(
+        mock_aioresponse,
+        f"{BASE_URL}/devices/config/4294976294/inputs/0",
+        "put",
+        update_response,
+        update_request,
+    )
+
+    await prepare_test_authenticated(
+        mock_aioresponse,
+        f"{BASE_URL}/devices/config/4294976294",
+        "put",
+        config_response,
+    )
+
+    device = Device(DEVICE_RAW_DATA, client_api_auth.auth)
+    await device.async_status(
+        0, "#1abcf2", 50, 50, foreground_color="#1cf22b", background_color="#f21c1c"
+    )


### PR DESCRIPTION
The Wiser API has gained an option to set separate colors for on and off states. Even though this is not yet documented in the API documentation, we can implement this fully backwards compatible (both in terms of the python API as well as the µGateway version).

<img width="662" height="381" alt="Bildschirmfoto 2026-06-18 um 08 54 55" src="https://github.com/user-attachments/assets/d51fe75c-f95f-4226-82be-01b51db9e23b" />
