### PR TITLE
Flag: Fallback if API response does not include name property

### DIFF
--- a/aiowiserbyfeller/system/flag.py
+++ b/aiowiserbyfeller/system/flag.py
@@ -34,9 +34,9 @@ class SystemFlag:
         return self.raw_data["value"]
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Human-readable name for the flag."""
-        return self.raw_data["name"]
+        return self.raw_data.get("name")
 
     async def async_refresh(self):
         """Fetch data from µGateway."""

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+ruff format aiowiserbyfeller tests
+ruff check aiowiserbyfeller tests --fix

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -28,6 +28,34 @@ async def test_async_get_system_flags(client_api_auth, mock_aioresponse):
 
 
 @pytest.mark.asyncio
+async def test_async_get_system_flags_without_name(client_api_auth, mock_aioresponse):
+    """Test async_get_system_flags when the gateway omits the name field (older firmware)."""
+    response_json = {
+        "data": [
+            {
+                "id": 16,
+                "value": True,
+                "symbol": "present",
+            }
+        ],
+        "status": "success",
+    }
+
+    await prepare_test_authenticated(
+        mock_aioresponse, f"{BASE_URL}/system/flags", "get", response_json
+    )
+
+    actual = await client_api_auth.async_get_system_flags()
+
+    assert len(actual) == 1
+    assert isinstance(actual[0], SystemFlag)
+    assert actual[0].id == 16
+    assert actual[0].symbol == "present"
+    assert actual[0].value is True
+    assert actual[0].name is None
+
+
+@pytest.mark.asyncio
 async def test_async_create_system_flag(client_api_auth, mock_aioresponse):
     """Test async_create_system_flag."""
     response_json = {


### PR DESCRIPTION
My testbench V1 Gateway returned this flag value:
```
{
  "data": [
    {
      "id": 16,
      "value": true,
      "symbol": "present"
    }
  ],
  "status": "success"
}
```

Which leads to this error log line in HA:
```
Error while setting up wiser_by_feller platform for switch: 'name'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 455, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/wiser_by_feller/switch.py", line 34, in async_setup_entry
    WiserSystemFlag(coordinator, flag) for flag in coordinator.system_flags or []
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/wiser_by_feller/switch.py", line 107, in __init__
    if flag.name is not None:
       ^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aiowiserbyfeller/system/flag.py", line 39, in name
    return self.raw_data["name"]
           ~~~~~~~~~~~~~^^^^^^^^
KeyError: 'name'
```

This change fixes the flag name property to allow for that.